### PR TITLE
fix restore_window_metrics to allow downward resizing below last stored size

### DIFF
--- a/magnus
+++ b/magnus
@@ -28,6 +28,8 @@ class Main(object):
         self.window_metrics_restored = False
         self.decorations_height = 0
         self.decorations_width = 0
+        self.min_x = 300
+        self.min_y = 300
         self.last_x = -1
         self.last_y = -1
         self.refresh_interval = 250
@@ -98,7 +100,7 @@ class Main(object):
 
         # the window
         self.w = Gtk.ApplicationWindow.new(self.app)
-        self.w.set_size_request(300, 300)
+        self.w.set_size_request(self.min_x, self.min_y)
         self.w.set_title("Magnus")
         self.w.connect("destroy", lambda a: self.app.quit())
         self.w.connect("configure-event", self.read_window_size)
@@ -293,7 +295,8 @@ class Main(object):
         scr = self.w.get_screen()
         sw = float(scr.get_width())
         sh = float(scr.get_height())
-        self.w.set_size_request(
+        self.w.set_size_request(self.min_x, self.min_y)
+        self.w.resize(
             int(sw * metrics["ww"]), int(sh * metrics["wh"]))
         self.w.move(int(sw * metrics["wx"]), int(sh * metrics["wy"]))
 

--- a/magnus
+++ b/magnus
@@ -28,8 +28,8 @@ class Main(object):
         self.window_metrics_restored = False
         self.decorations_height = 0
         self.decorations_width = 0
-        self.min_x = 300
-        self.min_y = 300
+        self.min_width = 300
+        self.min_height = 300
         self.last_x = -1
         self.last_y = -1
         self.refresh_interval = 250
@@ -100,7 +100,7 @@ class Main(object):
 
         # the window
         self.w = Gtk.ApplicationWindow.new(self.app)
-        self.w.set_size_request(self.min_x, self.min_y)
+        self.w.set_size_request(self.min_width, self.min_height)
         self.w.set_title("Magnus")
         self.w.connect("destroy", lambda a: self.app.quit())
         self.w.connect("configure-event", self.read_window_size)
@@ -295,7 +295,7 @@ class Main(object):
         scr = self.w.get_screen()
         sw = float(scr.get_width())
         sh = float(scr.get_height())
-        self.w.set_size_request(self.min_x, self.min_y)
+        self.w.set_size_request(self.min_width, self.min_height)
         self.w.resize(
             int(sw * metrics["ww"]), int(sh * metrics["wh"]))
         self.w.move(int(sw * metrics["wx"]), int(sh * metrics["wy"]))


### PR DESCRIPTION
This is a fix for [issue #10](https://github.com/stuartlangridge/magnus/issues/10). It appears to resolve the issue as the window can always be sized down as low as 300x300 regardless of what size it was when it was last closed. The window also opens to the last saved dimensions, as expected.

* Changed **restore_window_metrics** to perform **set_size_request** followed by **resize**.
* **set_size_request** sets a minimum size, then **resize** sets the size to the stored dimensions.
* Created **self.min_width** and **self.min_height** to be used in both **restore_window_metrics** and **start_everything_first_time**.