### PR TITLE
add position lock feature - center of view (mouse not tracked)

### DIFF
--- a/magnus
+++ b/magnus
@@ -69,6 +69,8 @@ class Main(object):
             print("      even if the mouse has not moved")
             print("  --position x y")
             print("    Set center of view, disable mouse tracking")
+            print("  --no-grab")
+            print("    Disable grab ability, when --position is used")
             return 0
 
         if "--force-refresh" in args:

--- a/magnus
+++ b/magnus
@@ -41,7 +41,7 @@ class Main(object):
         self.grab_x = 0
         self.grab_y = 0
         self.grab_lock = False
-        self.grab_enable = True
+        self.grab_enable = False
 
     def handle_shutdown(self, app):
         if self.started_by_keypress:
@@ -69,8 +69,8 @@ class Main(object):
             print("      even if the mouse has not moved")
             print("  --position x y")
             print("    Set center of view, disable mouse tracking")
-            print("  --no-grab")
-            print("    Disable grab ability, when --position is used")
+            print("  --grab")
+            print("    Enables grab ability, when --position is used")
             return 0
 
         if "--force-refresh" in args:
@@ -85,8 +85,8 @@ class Main(object):
             self.position_x = int(args[i+1])
             self.position_y = int(args[i+2])
 
-        if '--no-grab' in args:
-            self.grab_enable = False
+        if '--grab' in args:
+            self.grab_enable = True
 
         # Override refresh rate on command line
         for arg in args:

--- a/magnus
+++ b/magnus
@@ -41,6 +41,7 @@ class Main(object):
         self.grab_x = 0
         self.grab_y = 0
         self.grab_lock = False
+        self.grab_enable = True
 
     def handle_shutdown(self, app):
         if self.started_by_keypress:
@@ -81,6 +82,9 @@ class Main(object):
             self.position_lock = True
             self.position_x = int(args[i+1])
             self.position_y = int(args[i+2])
+
+        if '--no-grab' in args:
+            self.grab_enable = False
 
         # Override refresh rate on command line
         for arg in args:
@@ -211,6 +215,8 @@ class Main(object):
         self.set_zoom(zoom)
 
     def grab_on(self, a,b):
+        if not self.grab_enable:
+            return
         display = Gdk.Display.get_default()
         (screen, x, y, modifier) = display.get_pointer()
         self.grab_lock = True

--- a/magnus
+++ b/magnus
@@ -38,10 +38,10 @@ class Main(object):
         self.position_lock = False
         self.position_x = 0
         self.position_y = 0
-        self.grab_x = 0
-        self.grab_y = 0
-        self.grab_lock = False
-        self.grab_enable = False
+        self.drag_x = 0
+        self.drag_y = 0
+        self.drag_lock = False
+        self.drag_enable = False
 
     def handle_shutdown(self, app):
         if self.started_by_keypress:
@@ -69,8 +69,8 @@ class Main(object):
             print("      even if the mouse has not moved")
             print("  --position x y")
             print("    Set center of view, disable mouse tracking")
-            print("  --grab")
-            print("    Enables grab ability, when --position is used")
+            print("  --drag")
+            print("    Enables drag ability, when --position is used")
             return 0
 
         if "--force-refresh" in args:
@@ -85,8 +85,8 @@ class Main(object):
             self.position_x = int(args[i+1])
             self.position_y = int(args[i+2])
 
-        if '--grab' in args:
-            self.grab_enable = True
+        if '--drag' in args:
+            self.drag_enable = True
 
         # Override refresh rate on command line
         for arg in args:
@@ -184,8 +184,8 @@ class Main(object):
             Keybinder.bind("<Alt><Super>minus", self.zoom_out, zoom)
 
         # bind mouse drag
-        self.w.connect("button-press-event", self.grab_on)
-        self.w.connect("button-release-event", self.grab_off)
+        self.w.connect("button-press-event", self.drag_on)
+        self.w.connect("button-release-event", self.drag_off)
 
         # and, go
         self.w.show_all()
@@ -216,17 +216,17 @@ class Main(object):
         zoom.set_active(current_index + 1)
         self.set_zoom(zoom)
 
-    def grab_on(self, a,b):
-        if not self.grab_enable:
+    def drag_on(self, a,b):
+        if not self.drag_enable:
             return
         display = Gdk.Display.get_default()
         (screen, x, y, modifier) = display.get_pointer()
-        self.grab_lock = True
-        self.grab_x = x
-        self.grab_y = y
+        self.drag_lock = True
+        self.drag_x = x
+        self.drag_y = y
 
-    def grab_off(self, a,b):
-        self.grab_lock = False
+    def drag_off(self, a,b):
+        self.drag_lock = False
 
     def read_window_decorations_size(self, win, alloc):
         sz = self.w.get_size()
@@ -295,23 +295,23 @@ class Main(object):
     def poll(self, force_refresh=False):
         if self.position_lock:
 
-            if self.grab_lock:
-    			# if grabbed, move position lock
+            if self.drag_lock:
+    			# if dragged, move position lock
 
                 display = Gdk.Display.get_default()
                 (screen, x, y, modifier) = display.get_pointer()
 
                 # get delta
-                dx = (self.grab_x - x) // self.zoomlevel
-                dy = (self.grab_y - y) // self.zoomlevel
+                dx = (self.drag_x - x) // self.zoomlevel
+                dy = (self.drag_y - y) // self.zoomlevel
 
                 # apply delta
                 self.position_x += dx
                 self.position_y += dy
 
-                # reset grab start to current position
-                self.grab_x = x
-                self.grab_y = y
+                # reset drag start to current position
+                self.drag_x = x
+                self.drag_y = y
 
             # use coordinates from position lock
             x,y = self.position_x,self.position_y

--- a/magnus
+++ b/magnus
@@ -70,7 +70,7 @@ class Main(object):
             print("  --position x y")
             print("    Set center of view, disable mouse tracking")
             print("  --drag")
-            print("    Enables drag ability, when --position is used")
+            print("    Enables drag ability of main view, when --position is used")
             return 0
 
         if "--force-refresh" in args:

--- a/magnus
+++ b/magnus
@@ -38,6 +38,9 @@ class Main(object):
         self.position_lock = False
         self.position_x = 0
         self.position_y = 0
+        self.grab_x = 0
+        self.grab_y = 0
+        self.grab_lock = False
 
     def handle_shutdown(self, app):
         if self.started_by_keypress:
@@ -174,6 +177,10 @@ class Main(object):
             Keybinder.bind("<Alt><Super>equal", self.zoom_in, zoom)
             Keybinder.bind("<Alt><Super>minus", self.zoom_out, zoom)
 
+        # bind mouse drag
+        self.w.connect("button-press-event", self.grab_on)
+        self.w.connect("button-release-event", self.grab_off)
+
         # and, go
         self.w.show_all()
 
@@ -202,6 +209,16 @@ class Main(object):
             return
         zoom.set_active(current_index + 1)
         self.set_zoom(zoom)
+
+    def grab_on(self, a,b):
+        display = Gdk.Display.get_default()
+        (screen, x, y, modifier) = display.get_pointer()
+        self.grab_lock = True
+        self.grab_x = x
+        self.grab_y = y
+
+    def grab_off(self, a,b):
+        self.grab_lock = False
 
     def read_window_decorations_size(self, win, alloc):
         sz = self.w.get_size()
@@ -269,8 +286,30 @@ class Main(object):
 
     def poll(self, force_refresh=False):
         if self.position_lock:
+
+            if self.grab_lock:
+    			# if grabbed, move position lock
+
+                display = Gdk.Display.get_default()
+                (screen, x, y, modifier) = display.get_pointer()
+
+                # get delta
+                dx = (self.grab_x - x) // self.zoomlevel
+                dy = (self.grab_y - y) // self.zoomlevel
+
+                # apply delta
+                self.position_x += dx
+                self.position_y += dy
+
+                # reset grab start to current position
+                self.grab_x = x
+                self.grab_y = y
+
+            # use coordinates from position lock
             x,y = self.position_x,self.position_y
+
         else:
+			# get new coordinates
             display = Gdk.Display.get_default()
             (screen, x, y, modifier) = display.get_pointer()
             if x == self.last_x and y == self.last_y:

--- a/magnus
+++ b/magnus
@@ -63,6 +63,8 @@ class Main(object):
             print("  --force-refresh")
             print("    Refresh continually (according to refresh interval)")
             print("      even if the mouse has not moved")
+            print("  --position x y")
+            print("    Set center of view, disable mouse tracking")
             return 0
 
         if "--force-refresh" in args:

--- a/magnus
+++ b/magnus
@@ -35,6 +35,9 @@ class Main(object):
         self.refresh_interval = 250
         self.started_by_keypress = False
         self.force_refresh = False
+        self.position_lock = False
+        self.position_x = 0
+        self.position_y = 0
 
     def handle_shutdown(self, app):
         if self.started_by_keypress:
@@ -66,6 +69,13 @@ class Main(object):
             # If this argument is supplied, refresh the view even if the mouse
             # has not moved. Useful if the screen content is video.
             self.force_refresh = True
+
+
+        if '--position' in args:
+            i = args.index('--position')
+            self.position_lock = True
+            self.position_x = int(args[i+1])
+            self.position_y = int(args[i+2])
 
         # Override refresh rate on command line
         for arg in args:
@@ -256,14 +266,18 @@ class Main(object):
             width, height, width * len(light))
 
     def poll(self, force_refresh=False):
-        display = Gdk.Display.get_default()
-        (screen, x, y, modifier) = display.get_pointer()
-        if x == self.last_x and y == self.last_y:
-            # bail if nothing would be different
-            if not force_refresh and not self.force_refresh:
-                return True
-        self.last_x = x
-        self.last_y = y
+        if self.position_lock:
+            x,y = self.position_x,self.position_y
+        else:
+            display = Gdk.Display.get_default()
+            (screen, x, y, modifier) = display.get_pointer()
+            if x == self.last_x and y == self.last_y:
+                # bail if nothing would be different
+                if not force_refresh and not self.force_refresh:
+                    return True
+            self.last_x = x
+            self.last_y = y
+
         if (x > self.window_x and
                 x <= (self.window_x + self.width + self.decorations_width) and
                 y > self.window_y and

--- a/magnus
+++ b/magnus
@@ -296,7 +296,7 @@ class Main(object):
         if self.position_lock:
 
             if self.drag_lock:
-    			# if dragged, move position lock
+                # if dragged, move position lock
 
                 display = Gdk.Display.get_default()
                 (screen, x, y, modifier) = display.get_pointer()
@@ -317,7 +317,7 @@ class Main(object):
             x,y = self.position_x,self.position_y
 
         else:
-			# get new coordinates
+            # get new coordinates
             display = Gdk.Display.get_default()
             (screen, x, y, modifier) = display.get_pointer()
             if x == self.last_x and y == self.last_y:


### PR DESCRIPTION
This allows to set center of view from command line - mouse will not be tracked.
It is hard to find magnifier that does no track mouse.
It can be useful for playing old games that have small window only, for example.
